### PR TITLE
added documentation for usage with a local instance of the von-network

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,58 @@ The driver returns the following metadata in addition to a DID document:
 
 * `nymResponse`: Response to the Indy `GET_NYM` operation, including `txnTime`, `state_proof`, and other information.
 * `attrResponse`: Response to the Indy `GET_ATTR` operation, including `txnTime`, `state_proof`, and other information.
+
+
+## Usage with local Von-Network
+
+For development and testing it may be useful to run a local instance of the [von-network](https://github.com/bcgov/von-network) in a Docker container
+and resolve DIDs with this Driver.
+#### Setting up the Von-Network
+[This Tutorial](https://github.com/bcgov/von-network/blob/main/docs/UsingVONNetwork.md) explains how to set up the 
+von-network. Since the Resolver will run in a separate Docker container, the von-network needs to use the IP address
+of the host machine for the nodes, not the Docker Host IP.
+This can be achieved by running `./manage start <host_ip>` where `<host_ip>` is the IP address of the host machine. <br/>
+**Note**: If you followed the tutorial and already started the network, you need to run `./manage down` first to delete all
+the data in the ledger. After this you can run `./manage start <host_ip>`.<br/>
+After the von-network started, the genesis file is available at `http://localhost:9000/genesis`.
+
+#### Usage with this Driver
+Copy the genesis file into a new file (e.g. `von-local.txn`) in the `sovrin` directory of this driver.
+Open `docker/Dockerfile` and append the environment variables like this:
+```agsl
+ENV uniresolver_driver_did_indy_libIndyPath=
+ENV uniresolver_driver_did_indy_poolConfigs=sovrin;./sovrin/sovrin.txn;...;von:local;./sovrin/von-local.txn
+ENV uniresolver_driver_did_indy_poolVersions=sovrin;2;...;von:local;2
+ENV uniresolver_driver_did_indy_walletNames=sovrin;w1;...;von:local;w19
+ENV uniresolver_driver_did_indy_submitterDidSeeds=sovrin;_;...;von:local;_
+```
+A DID in the von-network can then be queried with `curl -X GET http://localhost:8080/1.0/identifiers/did:indy:von:local:<DID>`
+where `<DID>` is the DID that should be resolved.
+
+#### Usage with the Universal Resolver
+Create a new directory `networks` in the Resolver directory. Create a file in this directory called `von-local.txn` and
+copy the genesis file in there.
+To make this file available to the Indy Driver, in the Resolver adjust `docker-compose.yml`.
+Find the `driver-did-indy` service and add a volume like this:
+```
+  driver-did-indy:
+    image: universalresolver/driver-did-indy:latest
+    environment:
+      ...
+    ports:
+      ...
+    volumes:
+      - ./networks/von-local.txn:/var/lib/jetty/sovrin/von-local.txn
+```
+This copies the `von-local.txn` file to the driver container. Finally, adjust the `.env` file in the Resolver directory.
+Find the entries for `uniresolver_driver_did_indy_poolConfigs`, `uniresolver_driver_did_indy_poolVersions`, 
+`uniresolver_driver_did_indy_walletNames` and `uniresolver_driver_did_indy_submitterDidSeeds` and append them like this:
+```
+uniresolver_driver_did_indy_libIndyPath=
+uniresolver_driver_did_indy_poolConfigs=sovrin;./sovrin/sovrin.txn;...;von:local;./sovrin/von-local.txn
+uniresolver_driver_did_indy_poolVersions=sovrin;2;...;von:local;2
+uniresolver_driver_did_indy_walletNames=sovrin;w1;...;von:local;w13
+uniresolver_driver_did_indy_submitterDidSeeds=sovrin;_;...;von:local;_
+```
+A DID in the von-network can then be queried with `curl -X GET http://localhost:8080/1.0/identifiers/did:indy:von:local:<DID>`
+where `<DID>` is the DID that should be resolved.


### PR DESCRIPTION
As mentioned [here](https://github.com/decentralized-identity/uni-resolver-driver-did-indy/issues/3) I think it would be helpful for some developers to have a section about using this driver with a local instance of the von-network.
In this PR I added a section to the README describing what I did to make it work.
I included sections about how to use it when running only this driver and when running the Universal Resolver, but I can also remove the latter.
I am not sure whether it might be better to put this in a separate file instead to not clutter the README to much. 